### PR TITLE
Add eval_batch_size for evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ output_dir: ./completed-model
 # training hyperparameters
 batch_size: 8
 micro_batch_size: 2
+eval_batch_size: 2
 num_epochs: 3
 warmup_steps: 100
 learning_rate: 0.00003

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -47,6 +47,7 @@ def setup_trainer(cfg, train_dataset, eval_dataset, model, tokenizer):
 
     training_args = transformers.TrainingArguments(
         per_device_train_batch_size=cfg.micro_batch_size,
+        per_device_eval_batch_size=cfg.eval_batch_size,
         gradient_accumulation_steps=cfg.gradient_accumulation_steps,
         num_train_epochs=cfg.num_epochs,
         learning_rate=cfg.learning_rate,


### PR DESCRIPTION
Problem:

I would OOM during the evaluation stage despite setting `micro_batch_size` to be low. Turns out that batch size for eval using a different parameter.

Proposal:

New config for eval stage for lower VRAM GPUs.

Edit:

Since it's now a somewhat required argument, I'm not sure whether we should
- assert value exist
- set some default if not in config